### PR TITLE
Genx setters fix 20220404

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ make thrift-compiler -j$(nproc)
 
 ```
 docker build -t thrift build/docker/ubuntu-bionic
-docker run --rm -it --entrypoint bash -v (pwd):/thrift_src thrift
+docker run --rm -it --entrypoint bash -v $(pwd):/thrift_src thrift
 
 # Once inside docker container
 cd /thrift_src

--- a/compiler/cpp/src/thrift/generate/t_java_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_java_generator.cc
@@ -2632,7 +2632,7 @@ void t_java_generator::generate_java_bean_boilerplate(ostream& out, t_struct* ts
       if (bean_style_) {
         out << "void";
       } else {
-        out << type_name(tstruct);
+        out << tstruct->get_name();
       }
       out << " set" << cap_name << "(byte[] " << field_name << ") {" << endl;
       indent(out) << "  this." << field_name << " = " << field_name << " == null ? (java.nio.ByteBuffer)null";
@@ -2655,7 +2655,7 @@ void t_java_generator::generate_java_bean_boilerplate(ostream& out, t_struct* ts
     if (bean_style_) {
       out << "void";
     } else {
-      out << type_name(tstruct);
+      out << tstruct->get_name();
     }
     out << " set" << cap_name << "(" << (type_can_be_null(type) ? (java_nullable_annotation() + " ") : "")
         << ftnm << " " << field_name << ") {" << endl;


### PR DESCRIPTION
    java-generator: Allow builder-style setters again
    
    - If java.oneOf was enabled then the setters would declare the Genx.*
      prefixed type as the return type, which results in a compiler error
      since the class cannot know whether _this_ is an instance of the
      Genx.* type or not.
    - This change uses the original type name for the return type for such
      setters.
